### PR TITLE
Add images for mangostwo, fixes #1

### DIFF
--- a/mangostwo/docker-compose.yml
+++ b/mangostwo/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3'
+
+services:
+   db:
+     image: ssorriaux/mangostwo-database-mysql:latest
+     volumes:
+       - db_data:/var/lib/mysql
+     restart: always
+     environment:
+       MYSQL_ROOT_PASSWORD: mangos
+
+   realmd:
+     depends_on:
+       - db
+     image: ssorriaux/mangostwo-realmd:latest
+     ports:
+       - "3724:3724"
+     restart: always
+     environment:
+       LOGIN_DATABASE_INFO: db;3306;root;mangos;realmd
+
+   server:
+     depends_on:
+       - db
+       - realmd
+     image: ssorriaux/mangostwo-server:latest
+     volumes:
+       - mangos_maps:/etc/mangos/maps
+       - mangos_vmaps:/etc/mangos/vmaps
+       - mangos_mmaps:/etc/mangos/mmaps
+       - mangos_dbc:/etc/mangos/dbc
+     ports:
+       - "8085:8085"
+     restart: always
+     environment:
+       LOGIN_DATABASE_INFO: db;3306;root;mangos;realmd
+       WORLD_DATABASE_INFO: db;3306;root;mangos;mangos
+       CHARACTER_DATABASE_INFO: db;3306;root;mangos;characters
+volumes:
+    db_data:
+    mangos_maps:
+    mangos_vmaps:
+    mangos_mmaps:
+    mangos_dbc:

--- a/mangostwo/mangosd/Dockerfile
+++ b/mangostwo/mangosd/Dockerfile
@@ -1,0 +1,32 @@
+FROM gcc:7.3.0 as builder
+ARG MANGOS_SERVER_VERSION=master
+
+RUN apt-get update -qq && \
+    apt-get install openssl libssl-dev cmake -y && \
+    git clone https://github.com/mangostwo/server.git -b ${MANGOS_SERVER_VERSION} --recursive && \
+    cd server && \
+    cmake . -DBUILD_REALMD=No -DBUILD_TOOLS=No -DCONF_DIR=conf/ && \
+    make -j4 && \
+    make install -j4
+
+FROM debian:9
+MAINTAINER Stephen SORRIAUX <stephen.sorriaux@gmail.com>
+EXPOSE 8085
+ENV LOGIN_DATABASE_INFO=127.0.0.1;3306;root;mangos;realmd
+ENV WORLD_DATABASE_INFO=127.0.0.1;3306;root;mangos;mangos1
+ENV CHARACTER_DATABASE_INFO=127.0.0.1;3306;root;mangos;character1
+WORKDIR /etc/mangos/
+COPY --from=builder /server/bin .
+RUN apt-get update && \
+    apt-get install wget libstdc++6 libmysql++-dev libssl-dev -y && \
+    useradd -ms /bin/bash mangos && \
+    wget --no-check-certificate https://raw.githubusercontent.com/StephenSorriaux/mangos-docker/master/launch_mangosd.sh && \
+    chmod -R a+x . && \
+    mv conf/mangosd.conf.dist conf/mangosd.conf && \
+    sed -i 's/^LoginDatabaseInfo            =.*$/LoginDatabaseInfo            = LOGIN_DATABASE_INFO/' conf/mangosd.conf && \
+    sed -i 's/^WorldDatabaseInfo            =.*$/WorldDatabaseInfo            = WORLD_DATABASE_INFO/' conf/mangosd.conf && \
+    sed -i 's/^CharacterDatabaseInfo        =.*$/CharacterDatabaseInfo        = CHARACTER_DATABASE_INFO/' conf/mangosd.conf && \
+    chown -R mangos:mangos . && \
+    rm -rf /var/lib/apt/lists/*
+USER mangos
+CMD ["./launch_mangosd.sh"]

--- a/mangostwo/mysql-database/Dockerfile
+++ b/mangostwo/mysql-database/Dockerfile
@@ -1,0 +1,20 @@
+FROM mysql:5.7
+MAINTAINER Stephen SORRIAUX <stephen.sorriaux@gmail.com>
+EXPOSE 3306
+ARG MANGOS_DATABASE_VERSION=master
+
+ENV MANGOS_DATABASE_REALM_NAME=MyAwesomeWowServer
+ENV MANGOS_SERVER_VERSION=2
+ENV MANGOS_DB_RELEASE=Rel21
+
+RUN apt-get update && \
+    apt-get install git wget -y && \
+    git clone https://github.com/mangostwo/database.git -b ${MANGOS_DATABASE_VERSION} --recursive && \
+    wget --no-check-certificate https://raw.githubusercontent.com/StephenSorriaux/mangos-docker/master/launch_mysql.sh && \
+    chmod a+x launch_mysql.sh && \
+    apt-get remove --purge --force-yes -y git wget && \
+    apt-get -y autoremove && \
+    rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["./launch_mysql.sh"]
+CMD ["mysqld"]

--- a/mangostwo/realmd/Dockerfile
+++ b/mangostwo/realmd/Dockerfile
@@ -1,0 +1,27 @@
+FROM gcc:7.3.0 as builder
+ARG MANGOS_SERVER_VERSION=master
+RUN apt-get update -qq && \
+    apt-get install openssl libssl-dev cmake -y && \
+    git clone https://github.com/mangostwo/server.git -b ${MANGOS_SERVER_VERSION} --recursive && \
+    cd server && \
+    cmake . -DBUILD_MANGOSD=No -DBUILD_TOOLS=No -DCONF_DIR=conf/ && \
+    make -j4 && \
+    make install -j4
+
+FROM debian:9
+MAINTAINER Stephen SORRIAUX <stephen.sorriaux@gmail.com>
+EXPOSE 3724
+ENV LOGIN_DATABASE_INFO=127.0.0.1;3306;root;mangos;realmd
+WORKDIR /etc/mangos/
+COPY --from=builder /server/bin/ .
+RUN apt-get update && \
+    apt-get install wget libmysql++-dev libssl-dev -y && \
+    useradd -ms /bin/bash realm && \
+    wget https://raw.githubusercontent.com/StephenSorriaux/mangos-docker/master/launch_realmd.sh && \
+    chmod -R a+x . && \
+    mv conf/realmd.conf.dist conf/realmd.conf && \
+    sed -i 's/^LoginDatabaseInfo      =.*$/LoginDatabaseInfo      = LOGIN_DATABASE_INFO/' conf/realmd.conf && \
+    chown -R realm:realm . && \
+    rm -rf /var/lib/apt/lists/*
+USER realm
+CMD ["./launch_realmd.sh"]


### PR DESCRIPTION
This PR adds images for MangosTwo but also a docker-compose to make the installation easier.

Fixes #1 